### PR TITLE
Add Song IDs page

### DIFF
--- a/public/docs/Brawl/Song_IDs.md
+++ b/public/docs/Brawl/Song_IDs.md
@@ -514,10 +514,10 @@ SSE Data Select | Y12 | 282A
 Step: The Research Facility B | Y13 | 282B
 Step: Subspace Ver.2 | Y14 | 282C
 Step: Subspace Ver.3 | Y15 | 282D
+Halberd Engine Hum | Y16 | 282E
+SSE Final Results | Y17 | 282F
 ```
 A number of these tracks are not officially named, and have unofficial names in the table.
-Y16/282E is the ambient background SFX that plays during Battleship Halberd Exterior.
-Y17/282F is an ambient, monotonous hum sound effect.
 
 Various jingles (Zxx filenames)
 None of these songs loop.

--- a/public/docs/Brawl/Song_IDs.md
+++ b/public/docs/Brawl/Song_IDs.md
@@ -1,5 +1,44 @@
 ## Regular Music
-Mario Franchise (Axx filenames)
+
+Super Smash Bros. Brawl franchise (Xxx filenames)
+```handsontable
+# COLUMNS
+Song Title
+Song Filename
+Song ID
+# DATA
+Super Smash Bros. Brawl Main Theme | X01 | 26F9
+Menu 1 | X02 | 26FA
+Menu 2 | X03 | 26FB
+Battlefield | X04 | 26FC
+Final Destination | X05 | 26FD
+[nameless] | X06 | 26FE
+Online Practice Stage | X07 | 26FF
+Results Display Screen | X08 | 2700
+Tournament Registration | X09 | 2701
+Tournament Grid | X10 | 2702
+Tournament Match End | X11 | 2703
+Classic: Results Screen | X13 | 2705
+All-Star Rest Area | X15 | 2707
+Home-Run Contest | X16 | 2708
+Cruel Brawl | X17 | 2709
+Boss Battle | X18 | 270A
+Trophy Gallery | X19 | 270B
+Sticker Album / Album / Chronicle | X20 | 270C
+Coin Launcher | X21 | 270D
+[nameless] | X22 | 270E
+Stage Builder | X23 | 270F
+Battlefield Ver. 2 | X25 | 2711
+Target Smash!! | X26 | 2712
+Credits | X27 | 2713
+```
+X06/26FE is the song that plays on the Classic mode score screen after defeating Master Hand.
+X12/2704 is not referenced anywhere.
+X14/2706 is referenced, codenamed "ENDING"
+X22/270E is the jingle that plays at the end of Classic mode, when your trophy lands on the table.
+X24/2710 is referenced, but has no codename
+
+Mario franchise (Axx filenames)
 ```handsontable
 # COLUMNS
 Song Title
@@ -26,3 +65,496 @@ Luigi Circuit | A21 | 2726
 Waluigi Pinball | A22 | 2727
 Rainbow Road | A23 | 2728
 ```
+A11/271E is referenced, codenamed "MLRPG02"
+A12/271F is referenced, codenamed "MORINOKINOKO"
+
+Donkey Kong franchise (Bxx filenames)
+```handsontable
+# COLUMNS
+Song Title
+Song Filename
+Song ID
+# DATA
+Jungle Level Ver.2 | B01 | 2729
+The Map Page / Bonus Level | B02 | 272A
+Opening (Donkey Kong) | B03 | 272B
+Donkey Kong | B04 | 272C
+King K.Rool / Ship Deck 2 | B05 | 272D
+Bramble Blast | B06 | 272E
+Battle for Storm Hill | B07 | 272F
+Jungle Level | B08 | 2730
+25m BGM | B09 | 2731
+DK Jungle 1 Theme (Barrel Blast) | B10 | 2732
+```
+
+The Legend of Zelda franchise (Cxx filenames)
+```handsontable
+# COLUMNS
+Song Title
+Song Filename
+Song ID
+# DATA
+Title (The Legend of Zelda) | C01 | 2733
+Main Theme (The Legend of Zelda) | C02 | 2734
+Great Temple / Temple | C03 | 2735
+The Dark World | C04 | 2736
+Hidden Mountain & Forest | C05 | 2737
+Tal Tal Heights | C07 | 2739
+Hyrule Field Theme | C08 | 273A
+Ocarina of Time Medley | C09 | 273B
+Song of Storms | C10 | 273C
+Molgera Battle | C11 | 273D
+Village of the Blue Maiden | C12 | 273E
+Gerudo Valley | C13 | 273F
+Termina Field | C14 | 2740
+Dragon Roost Island | C15 | 2741
+The Great Sea | C16 | 2742
+Main Theme (Twilight Princess) | C17 | 2743
+The Hidden Village | C18 | 2744
+Midna's Lament | C19 | 2745
+```
+C06/2738 is referenced, codenamed "KAZENOSAKANA"
+
+Metroid franchise (Dxx filenames)
+```handsontable
+# COLUMNS
+Song Title
+Song Filename
+Song ID
+# DATA
+Main Theme (Metroid) | D01 | 2746
+Norfair | D02 | 2747
+Ending (Metroid) | D03 | 2748
+Vs. Ridley | D04 | 2749
+Theme of Samus Aran, Space Warrior | D05 | 274A
+Sector 1 | D06 | 274B
+Opening / Menu (Metroid Prime) | D07 | 274C
+Vs. Parasite Queen | D08 | 274D
+Vs. Meta Ridley | D09 | 274E
+Multiplayer (Metroid Prime 2) | D10 | 274F
+```
+
+Yoshi franchise (Exx filenames)
+```handsontable
+# COLUMNS
+Song Title
+Song Filename
+Song ID
+# DATA
+Ending (Yoshi's Story) | E01 | 2750
+Obstacle Course (Summer) | E02 | 2751
+Yoshi's Island | E03 | 2752
+Flower Field | E05 | 2754
+Wildlands | E06 | 2755
+Obstacle Course (Winter) | E07 | 2751
+```
+When Obstacle Course plays on Yoshi's Island, E02 is used during spring and summer, while E07 is used during fall and winter.
+E04/2753 is referenced, codenamed "COCKIE"
+Song ID 2756 is referenced, codenamed "ATHLETIC2". Likely involved in handling the song switching on the Yoshi's Island stage.
+
+Kirby franchise (Fxx filenames)
+```handsontable
+# COLUMNS
+Song Title
+Song Filename
+Song ID
+# DATA
+The Legendary Air Ride Machine | F01 | 2757
+King Dedede's Theme | F02 | 2758
+Boss Theme Medley | F03 | 2759
+Butter Building | F04 | 275A
+Gourmet Race | F05 | 275B
+Meta Knight's Revenge | F06 | 275C
+Vs. Marx | F07 | 275D
+0² Battle | F08 | 275E
+Forest / Nature Area | F09 | 275F
+Checker Knights | F10 | 2760
+Frozen Hillside | F11 | 2761
+Squeak Squad Theme | F12 | 2762
+```
+
+Star Fox franchise (Gxx filenames)
+```handsontable
+# COLUMNS
+Song Title
+Song Filename
+Song ID
+# DATA
+Main Theme (Star Fox) | G01 | 2763
+Corneria | G02 | 2764
+Main Theme (Star Fox 64) | G03 | 2765
+Area 6 | G04 | 2766
+Star Wolf | G05 | 2767
+Space Battleground | G07 | 2769
+Break Through the Ice | G08 | 276A
+Star Wolf (Star Fox: Assault) | G09 | 276B
+Space Armada | G10 | 276C
+Area 6 Ver. 2 | G11 | 276D
+```
+G06/2768 is referenced, codenamed "COMMAND"
+
+Pokémon franchise (Hxx filenames)
+```handsontable
+# COLUMNS
+Song Title
+Song Filename
+Song ID
+# DATA
+Pokémon Main Theme | H01 | 276E
+Pokémon Center | H02 | 276F
+Road to Viridian City (From Pallet Town / Pewter City) | H03 | 2770
+Pokémon Gym / Evolution | H04 | 2771
+Wild Pokémon Battle! (Ruby / Sapphire) | H05 | 2772
+Victory Road | H06 | 2773
+Wild Pokémon Battle ! (Diamond / Pearl) | H07 | 2774
+Dialga / Palkia Battle at Spear Pillar! | H08 | 2775
+Team Galactic Battle! | H09 | 2776
+Route 209 | H10 | 2777
+```
+
+F-Zero franchise (Ixx filenames)
+```handsontable
+# COLUMNS
+Song Title
+Song Filename
+Song ID
+# DATA
+Mute City | I01 | 2778
+White Land | I02 | 2779
+Fire Field | I03 | 277A
+Car Select | I04 | 277B
+Dream Chaser | I05 | 277C
+Devil's Call in Your Heart | I06 | 277D
+Climb Up! And Get The Last Chance! | I07 | 277E
+Brain Cleaner | I08 | 277F
+Shotgun Kiss | I09 | 2780
+Planet Colors | I10 | 2781
+```
+
+Fire Emblem franchise (Jxx filenames)
+```handsontable
+# COLUMNS
+Song Title
+Song Filename
+Song ID
+# DATA
+Fire Emblem Theme | J02 | 2783
+Shadow Dragon Medley | J03 | 2784
+With Mila's Divine Protection (Celica Map 1) | J04 | 2785
+Preparing to Advance | J06 | 2787
+Winning Road - Roy's Hope | J07 | 2788
+Attack | J08 | 2789
+Against the Dark Knight | J09 | 278A
+Crimean Army Sortie | J10 | 278B
+Power-Hungry Fool | J11 | 278C
+Victory Is Near | J12 | 278D
+Ike's Theme | J13 | 278E
+```
+J01/2782 is not referenced anywhere, heavily implying a cut Fire Emblem song
+J06/2786 is not referenced anywhere, heavily implying another cut FE song
+
+Mother/Earthbound franchise (Kxx filenames)
+```handsontable
+# COLUMNS
+Song Title
+Song Filename
+Song ID
+# DATA
+Snowman | K01 | 278F
+Humoresque of a Little Dog | K05 | 2793
+Porky's Theme | K07 | 2795
+Mother 3 Love Theme | K08 | 2796
+Unfounded Revenge / Smashing Song of Praise | K09 | 2797
+You Call This a Utopia?! | K10 | 2798
+```
+K02/2790 is referenced, codenamed "SENTOUONIISAN"
+K03/2791 is referenced, codenamed "EIGHTMELODIES"
+K04/2792 is referenced, codenamed "SMILEANDTEARS"
+K06/2794 is referenced, codenamed "BECAUSE"
+
+Pikmin franchise (Lxx filenames)
+```handsontable
+# COLUMNS
+Song Title
+Song Filename
+Song ID
+# DATA
+World Map (Pikmin 2) | L01 | 2799
+Forest of Hope | L02 | 279A
+Environmental Noises | L03 | 279B
+Ai no Uta | L04 | 279C
+Tane no Uta | L05 | 279D
+Main Theme (Pikmin) | L06 | 279E
+Stage Clear / Title (Pikmin) | L07 | 279F
+Ai no Uta (French Version) | L08 | 27A0
+```
+
+Wario franchise (Mxx filenames)
+```handsontable
+# COLUMNS
+Song Title
+Song Filename
+Song ID
+# DATA
+WarioWare, Inc. | M01 | 27A1
+WarioWare, Inc. Medley | M02 | 27A2
+Mona Pizza's Song (JP) | M03 | 27A3
+Mona Pizza's Song | M04 | 27A4
+Mike's Song (JP) | M05 | 27A5
+Mike's Song | M06 | 27A6
+Ashley's Song (JP) | M07 | 27A7
+Ashley's Song | M08 | 27A8
+```
+M09 through M18 are snippets of music that play during microgames on the WarioWare stage if "WarioWare, Inc." is the song that's currently playing. They occupy song IDs 27A9 through 27B2.
+
+Animal Crossing franchise (Nxx filenames)
+```handsontable
+# COLUMNS
+Song Title
+Song Filename
+Song ID
+# DATA
+Title (Animal Crossing) | N01 | 27B3
+Go K.K. Rider! | N02 | 27B4
+2:00 a.m. | N03 | 27B5
+The Roost | N05 | 27B7
+Town Hall and Tom Nook's Store | N06 | 27B8
+K.K. Cruisin' | N07 | 27B9
+K.K. Western | N08 | 27BA
+K.K. Gumbo | N09 | 27BB
+Rockin' K.K. | N10 | 27BC
+DJ K.K. | N11 | 27BD
+K.K. Condor | N12 | 27BE
+```
+N04/27B6 is referenced, codenamed "RADIOTAISO"
+N07 through N12 only play during K.K. Rider's concerts on the Smashville stage (8pm on Saturday).
+
+Kid Icarus franchise (Pxx filenames)
+```handsontable
+# COLUMNS
+Song Title
+Song Filename
+Song ID
+# DATA
+Underworld | P01 | 27BF
+Title (Kid Icarus) | P02 | 27C0
+Skyworld | P03 | 27C1
+Kid Icarus Original Medley | P04 | 27C2
+```
+Oxx filenames were likely skipped to avoid confusion between the letter O and the number 0.
+
+Famicom franchise (Qxx filenames)
+```handsontable
+# COLUMNS
+Song Title
+Song Filename
+Song ID
+# DATA
+Famicom Medley | Q01 | 27C3
+Gyromite | Q02 | 27C4
+Chill (Dr. Mario) | Q04 | 27C6
+Clu Clu Land | Q05 | 27C7
+Balloon Trip | Q06 | 27C8
+Ice Climber | Q07 | 27C9
+Shin Onigashima | Q08 | 27CA
+Title (3D Hot Rally) | Q09 | 27CB
+Tetris: Type A | Q10 | 27CC
+Tetris: Type B | Q11 | 27CD
+Tunnel Scene (X) | Q12 | 27CE
+Power-Up Music | Q13 | 27CF
+Douchuumen (Nazo no Murasamejo) | Q14 | 27D0
+```
+Q03/27C5 is referenced, codenamed "SPORTSMEDLEY"
+
+Miscellaneous franchise (Rxx filenames)
+```handsontable
+# COLUMNS
+Song Title
+Song Filename
+Song ID
+# DATA
+Pictochat | R02 | 27D2
+[nameless] | R03 | 27D3
+Flat Zone 2 | R04 | 27D4
+Mario Tennis / Mario Golf | R05 | 27D5
+Lip's Theme (Panel de Pon) | R06 | 27D6
+Marionation Gear | R07 | 27D7
+Title (Big Brain Academy) | R08 | 27D8
+Golden Forest (1080°Snowboarding) | R09 | 27D9
+Mii Channel | R10 | 27DA
+Wii Shop Channel | R11 | 27DB
+Battle Scene / Final Boss (Golden Sun) | R12 | 27DC
+Shaberu! DS Cooking Navi | R13 | 27DD
+Excite Truck | R14 | 27DE
+Brain Age: Train Your Brain in Minutes a Day | R15 | 27DF
+Opening Theme (Wii Sports) | R16 | 27E0
+Charge! (Wii Play) | R17 | 27E1
+```
+R01/27D1 is referenced, codenamed "WILDTRACKS"
+R03 is codenamed "ELECTRO", and it is the ambient noise that plays on the Electroplankton stage
+
+Metal Gear franchise (Sxx filenames)
+```handsontable
+# COLUMNS
+Song Title
+Song Filename
+Song ID
+# DATA
+Encounter | S02 | 27E3
+Theme of Tara | S03 | 27E4
+Yell "Dead Cell" | S04 | 27E5
+Snake Eater (Instrumental) | S05 | 27E6
+MGS4 ~Theme of Love~ Smash Bros. Brawl Version | S06 | 27E7
+Cavern | S07 | 27E8
+Battle in the Base | S08 | 27E9
+Theme of Solid Snake | S10 | 27EB
+Calling to the Night | S11 | 27EC
+```
+S01/27E2 is referenced, codenamed "MAINTHEME"
+S09/27EA is referenced, codenamed "BEATMANIA"
+
+Txx filenames (a few Super Smash Bros. franchise songs)
+```handsontable
+# COLUMNS
+Song Title
+Song Filename
+Song ID
+# DATA
+Credits (Super Smash Bros.) | T01 | 27ED
+Menu (Super Smash Bros. Melee) | T02 | 27EE
+Opening (Super Smash Bros. Melee) | T03 | 27EF
+Vs. Master Hand | T05 | 27F1
+```
+T04/27F0 is referenced, codenamed "HOWTOPLAY"
+Vs. Master Hand only plays when fighting Master Hand at the end of Classic Mode.
+
+Sonic franchise (Uxx filenames)
+```handsontable
+# COLUMNS
+Song Title
+Song Filename
+Song ID
+# DATA
+Green Hill Zone | U01 | 27F2
+Scrap Brain Zone | U02 | 27F3
+Emerald Hill Zone | U03 | 27F4
+Angel Island Zone | U04 | 27F5
+Sonic Boom | U06 | 27F7
+Super Sonic Racing | U07 | 27F8
+Open Your Heart | U08 | 27F9
+Live & Learn | U09 | 27FA
+Sonic Heroes | U10 | 27FB
+Right There, Ride On | U11 | 27FC
+HIS WORLD (Instrumental) | U12 | 27FD
+Seven Rings In Hand | U13 | 27FE
+```
+U05/27F6 is referenced, codenamed "UCANDO"
+
+Super Smash Bros. Melee music (Wxx filenames)
+```handsontable
+# COLUMNS
+Song Title
+Song Filename
+Song ID
+# DATA
+Princess Peach's Castle (Melee) | W01 | 27FF
+Rainbow Cruise (Melee) | W02 | 2800
+Jungle Japes (Melee) | W03 | 2801
+Brinstar Depths (Melee) | W04 | 2802
+Yoshi's Island (Melee) | W05 | 2803
+Fountain of Dreams (Melee) | W06 | 2804
+Green Greens (Melee) | W07 | 2805
+Corneria (Melee) | W08 | 2806
+Pokémon Stadium (Melee) | W09 | 2807
+Poké Floats (Melee) | W10 | 2808
+Big Blue (Melee) | W11 | 2809
+Mother (Melee) | W12 | 280A
+Icicle Mountain (Melee) | W13 | 280B
+Flat Zone (Melee) | W14 | 280C
+Super Mario Bros. 3 (Melee) | W15 | 280D
+Battle Theme (Melee) | W16 | 280E
+Fire Emblem (Melee) | W17 | 280F
+Mach Rider (Melee) | W18 | 2810
+Mother 2 (Melee) | W19 | 2811
+Dr. Mario (Melee) | W20 | 2812
+Battlefield (Melee) | W21 | 2813
+Multi-Man Melee 1 (Melee) | W23 | 2815
+Temple (Melee) | W24 | 2816
+Final Destination (Melee) | W25 | 2817
+Kong Jungle (Melee) | W26 | 2818
+Brinstar (Melee) | W27 | 2819
+Venom  (Melee) | W28 | 281A
+Mute City (Melee) | W29 | 281B
+Menu (Melee) | W30 | 281C
+Giga Bowser (Melee) | W31 | 281D
+```
+W22/2814 is not referenced anywhere
+
+281E is a silent, unnamed song ID.
+
+Subspace Emissary franchise (Yxx filenames)
+```handsontable
+# COLUMNS
+Song Title
+Song Filename
+Song ID
+# DATA
+Adventure Map | Y01 | 281F
+Step: The Plain | Y02 | 2820
+Step: The Cave | Y03 | 2821
+Step: Subspace | Y04 | 2822
+Boss Battle Song 1 | Y05 | 2823
+SSE Results | Y06 | 2824
+Boss Battle Song 2 | Y07 | 2825
+Save Point | Y08 | 2826
+Step: The Jungle | Y09 | 2827
+Step: The Lake (False Bowser Battle) | Y10 | 2828
+Step: The Research Facility A | Y11 | 2829
+SSE Data Select | Y12 | 282A
+Step: The Research Facility B | Y13 | 282B
+Step: Subspace Ver.2 | Y14 | 282C
+Step: Subspace Ver.3 | Y15 | 282D
+```
+A number of these tracks are not officially named, and have unofficial names in the table.
+Y16/282E is the ambient background SFX that plays during Battleship Halberd Exterior.
+Y17/282F is an ambient, monotonous hum sound effect.
+
+Various jingles (Zxx filenames)
+None of these songs loop.
+```handsontable
+# COLUMNS
+Song Title
+Song Filename
+Song ID
+# DATA
+Victory! Mario | Z01 | 283D, 2845, 2848, 2849
+Victory! Donkey Kong | Z02 | 283E, 2857
+Victory! Zelda | Z03 | 283F, 284A, 284B, 2850, 2860
+Victory! Metroid | Z04 | 2840, 2854
+Victory! Yoshi | Z05 | 2841
+Victory! Kirby | Z06 | 2842, 2859
+Victory! Star Fox | Z07 | 2843, 284F
+Victory! Pokémon | Z08 | 2844, 2858, 285A, 285D, 285E
+Victory! F-Zero | Z10 | 2846
+Victory! Mother | Z11 | 2847, 2856
+Victory! Ice Climber | Z16 | 284C
+Victory! Fire Emblem | Z17 | 284D, 285B, 285F
+Victory! Game & Watch | Z18 | 284E
+Victory! Wario | Z21 | 2851
+Victory! Meta Knight | Z22 | 2852
+Victory! Kid Icarus | Z23 | 2853
+Victory! Pikmin | Z25 | 2855
+Victory! R.O.B. | Z35 | 285C
+Victory! Metal Gear | Z46 | 2861
+Victory! Sonic | Z47 | 2862
+Game Over | Z50 | 2863
+Game Over (rejected continue) | Z51 | 2864
+New Feature! Trophy | Z54 | 2867
+New Feature! Rare Item | Z55 | 2868
+New Feature! 3 | Z56 | 2869
+New Feature! 4 | Z57 | 286A
+New Feature! 5 | Z58 | 286B
+```
+Song IDs 2865 and 2866 are silent.
+There is 1 song ID for every character's victory theme, meaning that several song IDs reference the same file.
+Song IDs 285E and 285F likely correspond to victory themes for cut characters Mewtwo and Roy respectively, given that they point to the Pokémon and Fire Emblem themes.

--- a/public/docs/Brawl/Song_IDs.md
+++ b/public/docs/Brawl/Song_IDs.md
@@ -1,0 +1,28 @@
+## Regular Music
+Mario Franchise (Axx filenames)
+```handsontable
+# COLUMNS
+Song Title
+Song Filename
+Song ID
+# DATA
+Ground Theme (Super Mario Bros.) | A01 | 2714
+Underground Theme (Super Mario Bros.) | A02 | 2715
+Underwater Theme (Super Mario Bros.) | A03 | 2716
+Underground Theme (Super Mario Land) | A04 | 2717
+Airship Theme (Super Mario Bros. 3) | A05 | 2718
+Castle / Boss Fortress (Super Mario World / SMB 3) | A06 | 2719
+Title / Ending (Super Mario World) | A07 | 271A
+Main Theme (New Super Mario Bros.) | A08 | 271B
+Luigi's Mansion Theme | A09 | 271C
+Gritzy Desert | A10 | 271D
+Delfino Plaza | A13 | 2720
+Ricco Harbor | A14 | 2721
+Main Theme (Super Mario 64) | A15 | 2722
+Ground Theme 2 (Super Mario Bros.) | A16 | 2723
+Mario Bros. | A17 | 2724
+Mario Circuit | A20 | 2725
+Luigi Circuit | A21 | 2726
+Waluigi Pinball | A22 | 2727
+Rainbow Road | A23 | 2728
+```

--- a/public/docs/_pages.txt
+++ b/public/docs/_pages.txt
@@ -100,6 +100,7 @@ Brawl/
   Hitbox_Flags
   Item_Generation_Table
   Items
+  Song_IDs
 Tools/
   TestPage
 index


### PR DESCRIPTION
Adds a page that lists every song's filename and song ID. Lots of info ported from the OpenSA wiki, with some extra details from other research (especially [this page](https://smashboards.com/threads/brawl-music-track-list.158635/)). I'm too lazy to figure out how to properly preview my edits, so idk if the formatting will look correct or not. :)